### PR TITLE
Refactors the button tray a bit, gets access to the microphone.

### DIFF
--- a/soundwich/ButtonTrayView.swift
+++ b/soundwich/ButtonTrayView.swift
@@ -30,7 +30,7 @@ class ButtonTrayView: UIView {
     }
 
     func setupButtons() {
-        print("\n\n\n", "setupButtons")
+        // print("\n\n\n", "setupButtons")
         backgroundColor = UIColor(white: 44.0/255.0, alpha: 1.0)
 
         addSubview(loopButton)
@@ -51,14 +51,14 @@ class ButtonTrayView: UIView {
     }
 
     func setupRecording() {
-        print("\n\n\n", "setupRecording")
+        // print("\n\n\n", "setupRecording")
         let session = AVAudioSession.sharedInstance()
         if session.respondsToSelector("requestRecordPermission:") {
             session.requestRecordPermission({ (granted) -> Void in
                 if granted {
-                    print("\n\n\n", "granted")
+                    // print("\n\n\n", "granted")
                 } else {
-                    print("\n\n\n", "not granted")
+                    // print("\n\n\n", "not granted")
                 }
             })
         }

--- a/soundwich/ButtonTrayView.swift
+++ b/soundwich/ButtonTrayView.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import AVFoundation
 
 class ButtonTrayView: UIView {
 
@@ -14,7 +15,22 @@ class ButtonTrayView: UIView {
     var recordButton = RecordButton(frame: CGRect(x: 113, y: 13, width: 96, height: 96))
     var playPauseButton = PlayPauseButton(frame: CGRect(x: 228, y: 26, width: 68, height: 68))
 
-    override func didMoveToSuperview() {
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+
+        setupButtons()
+        setupRecording()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupButtons()
+        setupRecording()
+    }
+
+    func setupButtons() {
+        print("\n\n\n", "setupButtons")
         backgroundColor = UIColor(white: 44.0/255.0, alpha: 1.0)
 
         addSubview(loopButton)
@@ -32,6 +48,20 @@ class ButtonTrayView: UIView {
             action: "onTouchUpInside:",
             forControlEvents: .TouchUpInside
         )
+    }
+
+    func setupRecording() {
+        print("\n\n\n", "setupRecording")
+        let session = AVAudioSession.sharedInstance()
+        if session.respondsToSelector("requestRecordPermission:") {
+            session.requestRecordPermission({ (granted) -> Void in
+                if granted {
+                    print("\n\n\n", "granted")
+                } else {
+                    print("\n\n\n", "not granted")
+                }
+            })
+        }
     }
 
     func onTouchDown(sender: UIButton) {


### PR DESCRIPTION
The simulator gives you access to the mic by default, but tested this on my phone and it works. If you deny mic access, you have to go `Settings > Privacy > Microphone` to enable it (on a per-app basis) … not sure if there's a way to re-prompt in the app, but I'm skipping that for now.
